### PR TITLE
Set minimum stability requirement to "stable"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
             ]
         }
     },
-    "minimum-stability": "dev",
     "prefer-stable": true,
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Laravel 11 requires minimum stability "stable"